### PR TITLE
improved "message" part of log

### DIFF
--- a/Lucca.Logs.Shared/LuccaLogger.cs
+++ b/Lucca.Logs.Shared/LuccaLogger.cs
@@ -64,6 +64,10 @@ namespace Lucca.Logs.Shared
             }
 
             string message = formatter(state, exception);
+            if(message == "[null]" && exception != null)
+            {
+                message = exception.Message;
+            }
 
             // Log to NLog
             LogEventInfo eventInfo = CreateNlogEventInfo(eventId, exception, nLogLogLevel, message);


### PR DESCRIPTION
before : `[null]` was logged (and showing as such in nlog
now : the exception message is displayed