### PR TITLE
FIX : never send an empty appname

### DIFF
--- a/Lucca.Logs.AspnetLegacy/ExceptionLoggerHelper.cs
+++ b/Lucca.Logs.AspnetLegacy/ExceptionLoggerHelper.cs
@@ -6,24 +6,31 @@ namespace Lucca.Logs.AspnetLegacy
 {
     public static class ExceptionLoggerHelper
     {
+        public const string DefaultAppName = "UnknownAppName";
+
         /// <summary>
-        /// Helps logging an excpetions in an HttpContext
+        /// Helps logging an exception in an HttpContext
         /// </summary>
         public static void HttpLog(this Exception exception, HttpControllerContext context)
         {
-            Logger.LogException(exception, context.TryGetAppName());
+            Logger.LogException(exception, context.TryGetAppName() ?? DefaultAppName);
         }
 
         private static string TryGetAppName(this HttpControllerContext controllerContext)
         {
             if (controllerContext?.ControllerDescriptor?.ControllerType == null)
+            {
                 return null;
+            }
+
             string appNameSpace = controllerContext.ControllerDescriptor.ControllerType.Namespace;
             if (appNameSpace != null)
             {
                 string[] nsChunks = appNameSpace.Split('.');
                 if (nsChunks.Length > 0)
+                {
                     return nsChunks.FirstOrDefault();
+                }
             }
             return null;
         }


### PR DESCRIPTION
Fixes this sort or exceptions
http://opserver.lucca.local/exceptions/detail?id=8878f6a3-9451-45ac-b241-64e89b228efe&log=Legacy&store=RBX