### PR TITLE
REM : opserver redondant data

### DIFF
--- a/Lucca.Logs.Shared/LuccaLogger.cs
+++ b/Lucca.Logs.Shared/LuccaLogger.cs
@@ -50,12 +50,11 @@ namespace Lucca.Logs.Shared
 
             bool isError = logLevel == LogLevel.Error || logLevel == LogLevel.Critical;
 
-            Dictionary<string, string> customData = LuccaDataWrapper.GatherData(exception, _httpContextWrapper, isError, _appName);
-
             Guid? guid = null;
             if (_exceptionalWrapper.Enabled && exception != null && (_filters == null || _filters.LogToOpserver(exception)))
             {
-                guid = _httpContextWrapper.ExceptionalLog(exception, customData, _categoryName, _appName);
+                Dictionary<string, string> opServerData = LuccaDataWrapper.GatherData(exception, _httpContextWrapper, isError, _appName, false);
+                guid = _httpContextWrapper.ExceptionalLog(exception, opServerData, _categoryName, _appName);
             }
 
             if (!isLogging)
@@ -64,7 +63,7 @@ namespace Lucca.Logs.Shared
             }
 
             string message = formatter(state, exception);
-            if(message == "[null]" && exception != null)
+            if (message == "[null]" && exception != null)
             {
                 message = exception.Message;
             }
@@ -72,8 +71,8 @@ namespace Lucca.Logs.Shared
             // Log to NLog
             LogEventInfo eventInfo = CreateNlogEventInfo(eventId, exception, nLogLogLevel, message);
 
-            // Get cutom data and inject
-            AppendLuccaData(guid, eventInfo, _options, customData);
+            // Get full custom data and inject
+            AppendLuccaData(guid, eventInfo, _options, LuccaDataWrapper.GatherData(exception, _httpContextWrapper, isError, _appName, true));
 
             _nloLogger.Log(eventInfo);
         }


### PR DESCRIPTION
les logs opserver contiennent pas mal de redondance
http://opserver.lucca.local/exceptions/detail?id=11cc036c-47e7-4c14-b0c7-e2cd4afb1cad&log=login&store=RBX

ou de données vides
http://opserver.lucca.local/exceptions/detail?id=ba6c700b-9df6-41c3-a1d5-8c4e017f7e6e&log=Fired+and+forgotten+%2F+AfterUserPatch&store=RBX