### PR TITLE
Adds placeholder support for multiple OpServer exception stores

### DIFF
--- a/Lucca.Logs.Shared/LuccaLogger.cs
+++ b/Lucca.Logs.Shared/LuccaLogger.cs
@@ -64,7 +64,7 @@ namespace Lucca.Logs.Shared
             }
 
             string message = formatter(state, exception);
-            if(message == "[null]" && exception != null)
+            if (message == "[null]" && exception != null)
             {
                 message = exception.Message;
             }
@@ -85,7 +85,16 @@ namespace Lucca.Logs.Shared
                 eventInfo.Properties[kv.Key] = kv.Value;
             }
 
-            if (guid.HasValue)
+            if (!guid.HasValue)
+            {
+                return;
+            }
+
+            if (options.GuidWithPlaceHolder)
+            {
+                eventInfo.Properties[LuccaDataWrapper.Link] = String.Format(options.GuidLink, guid.Value.ToString("N"));
+            }
+            else
             {
                 eventInfo.Properties[LuccaDataWrapper.Link] = options.GuidLink + guid.Value.ToString("N");
             }

--- a/Lucca.Logs.Shared/LuccaLoggerOptions.cs
+++ b/Lucca.Logs.Shared/LuccaLoggerOptions.cs
@@ -33,8 +33,20 @@ namespace Lucca.Logs.Shared
         /// <summary>
         /// Base URI for external link 
         /// </summary>
-        /// <example>"http://opserver.lucca.local/exceptions/detail?id="</example>
-        public string GuidLink { get; set; } = "http://opserver.lucca.local/exceptions/detail?id=";
+        /// <example>"http://opserver.lucca.local/exceptions/detail?id={0}"</example>
+        public string GuidLink { get; set; } = "http://opserver.lucca.local/exceptions/detail?id={0}";
+
+        public bool GuidWithPlaceHolder
+        {
+            get
+            {
+                if (!_guidWithPlaceHolder.HasValue)
+                {
+                    _guidWithPlaceHolder = GuidLink.Contains("{0}");
+                }
+                return _guidWithPlaceHolder.Value;
+            }
+        }
 
         /// <summary>
         /// Separator between for EventId.Id and EventId.Name. Default to .
@@ -57,6 +69,7 @@ namespace Lucca.Logs.Shared
         internal ErrorStore ExplicitErrorStore { get; set; }
 
         private LoggingConfiguration _nlog;
+        private bool? _guidWithPlaceHolder;
 
         public ErrorStore GenerateExceptionalStore()
         {


### PR DESCRIPTION
In order to support Uri like
http://opserver.lucca.local/exceptions/detail?id=e4eed6ec-98c2-4611-952c-f2253ae5f750 *&store=Production*