### PR TITLE
Fix bad app name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-﻿*/bin/
+﻿
+*/bin/
 */obj/
 /.vs
 /.vscode

--- a/Lucca.Logs.AspnetLegacy/Logger.cs
+++ b/Lucca.Logs.AspnetLegacy/Logger.cs
@@ -22,7 +22,7 @@ namespace Lucca.Logs.AspnetLegacy
         /// <param name="appName">The current application name</param>
         public static void LogException(Exception ex, string appName, string message = null)
         {
-            _defaultLogger.Value.CreateLogger(appName).LogError(ex, message);
+            GetFactory.CreateLogger(appName).LogError(ex, message);
         }
 
         public static void LogInfo(object objectToSerializeAsMessage, string appName)
@@ -35,22 +35,22 @@ namespace Lucca.Logs.AspnetLegacy
         /// </summary> 
         public static void LogInfo(string message, string appName)
         {
-            _defaultLogger.Value.CreateLogger(appName).LogInformation(message);
+            GetFactory.CreateLogger(appName).LogInformation(message);
         }
 
         public static void LogDebug(string message, string appName)
         {
-            _defaultLogger.Value.CreateLogger(appName).LogDebug(message);
+            GetFactory.CreateLogger(appName).LogDebug(message);
         }
 
         public static void LogWarning(string message, string appName)
         {
-            _defaultLogger.Value.CreateLogger(appName).LogWarning(message);
+            GetFactory.CreateLogger(appName).LogWarning(message);
         }
 
         public static void LogCritical(string message, string appName)
         {
-            _defaultLogger.Value.CreateLogger(appName).LogCritical(message);
+            GetFactory.CreateLogger(appName).LogCritical(message);
         }
     }
 }


### PR DESCRIPTION
le problème existe depuis le passage sur le monolithe de 0.5.0 -> 0.5.2
https://github.com/LuccaSA/Lucca.Logs/compare/v0.5.0...v0.5.2
exemple : les erreurs timmi apparaissent en monolithe
http://opserver.lucca.local/exceptions/detail?id=60b40d4d70c046f7850b0f47e2acd267&store=Production

J'ai l'impression que la cause est sur les modifs de LuccaLogsProvider.cs ligne 61 categoryName -> _options.CurrentValue.ApplicationName
Puisque le builder sur Logger.LogException utilisait toujours le _defaultLogger au lieu DefaultFactory, l'appname sautait. si qqun a une meilleure explication, je prends.
j'ai donc corrigé le bug sur Lucca.Logs.AspnetLegacy.Logger pour qu'il utilsie le bon factory