### PR TITLE
Some luvin

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -18,12 +18,12 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '3.1.x'
+        dotnet-version: '6.0.x'
 
     - name: Install GitVersion
       uses: gittools/actions/gitversion/setup@v0.9.9
       with:
-          versionSpec: '5.6.8'
+          versionSpec: '5.8.1'
 
     - name: Use GitVersion
       id: gitversion # step id used as reference for output values

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,7 @@
     <Authors>Lucca team</Authors>
     <Description>Lucca.Logs</Description>
     <PackageProjectUrl>https://github.com/LuccaSA/Lucca.Logs/</PackageProjectUrl>
-    <Copyright>Copyright Lucca 2018</Copyright>
+    <Copyright>Copyright Lucca 2021</Copyright>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -32,7 +32,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(SourceLinkEnabled)' == 'true'">
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
   </ItemGroup>
 
 </Project>

--- a/Lucca.Logs.AspnetCore/GenericIExceptionQualifier.cs
+++ b/Lucca.Logs.AspnetCore/GenericIExceptionQualifier.cs
@@ -7,6 +7,7 @@ namespace Lucca.Logs.AspnetCore
 {
     public class GenericExceptionQualifier : IExceptionQualifier
     {
+        internal static readonly string DefaultErrorMessage = "Oops ! Something went wrong. Please contact your administrator";
         public virtual bool LogToOpserver(Exception exception)
         {
             var statusCode = StatusCode(exception);
@@ -22,7 +23,7 @@ namespace Lucca.Logs.AspnetCore
             _ => null,
         };
 
-        public virtual string GenericErrorMessage => "Oops ! Something went wrong. Please contact your administrator";
+        public virtual string GenericErrorMessage => DefaultErrorMessage;
 
         public virtual string PreferedResponseType(string path) => "application/json";
     }

--- a/Lucca.Logs.AspnetCore/GenericIExceptionQualifier.cs
+++ b/Lucca.Logs.AspnetCore/GenericIExceptionQualifier.cs
@@ -13,22 +13,14 @@ namespace Lucca.Logs.AspnetCore
             return !statusCode.HasValue || statusCode.Value >= HttpStatusCode.InternalServerError;
         }
 
-        public virtual bool DisplayExceptionDetails(Exception exception)
-        {
-            return false;
-        }
+        public virtual bool DisplayExceptionDetails(Exception exception) => false;
 
-        public virtual HttpStatusCode? StatusCode(Exception exception)
+        public virtual HttpStatusCode? StatusCode(Exception exception) => exception switch
         {
-            switch (exception)
-            {
-                case UnauthorizedAccessException _:
-                    return HttpStatusCode.Unauthorized;
-                case HttpRequestException _:
-                    return HttpStatusCode.InternalServerError;
-            }
-            return null;
-        }
+            UnauthorizedAccessException _ => HttpStatusCode.Unauthorized,
+            HttpRequestException _ => HttpStatusCode.InternalServerError,
+            _ => null,
+        };
 
         public virtual string GenericErrorMessage => "Oops ! Something went wrong. Please contact your administrator";
 

--- a/Lucca.Logs.AspnetCore/HttpContextParserCore.cs
+++ b/Lucca.Logs.AspnetCore/HttpContextParserCore.cs
@@ -56,27 +56,27 @@ namespace Lucca.Logs.AspnetCore
             HttpRequest = httpRequest;
         }
 
-        public string ExtractUrl(Uripart uriPart)
+        public string ExtractUrl(Uriparts uriPart)
         {
             var urlBuilder = new StringBuilder();
-            if ((uriPart & Uripart.Scheme) == Uripart.Scheme && !string.IsNullOrWhiteSpace(HttpRequest.Scheme))
+            if ((uriPart & Uriparts.Scheme) == Uriparts.Scheme && !string.IsNullOrWhiteSpace(HttpRequest.Scheme))
             {
                 urlBuilder.Append(HttpRequest.Scheme + "://");
             }
-            if ((uriPart & Uripart.Host) == Uripart.Host)
+            if ((uriPart & Uriparts.Host) == Uriparts.Host)
             {
                 urlBuilder.Append(HttpRequest.Host.Host);
             }
-            if ((uriPart & Uripart.Port) == Uripart.Port && HttpRequest.Host.Port > 0)
+            if ((uriPart & Uriparts.Port) == Uriparts.Port && HttpRequest.Host.Port > 0)
             {
                 urlBuilder.Append(":" + HttpRequest.Host.Port);
             }
-            if ((uriPart & Uripart.Path) == Uripart.Path)
+            if ((uriPart & Uriparts.Path) == Uriparts.Path)
             {
                 urlBuilder.Append(HttpRequest.PathBase.ToUriComponent());
                 urlBuilder.Append(HttpRequest.Path.ToUriComponent());
             }
-            if ((uriPart & Uripart.Query) == Uripart.Query)
+            if ((uriPart & Uriparts.Query) == Uriparts.Query)
             {
                 urlBuilder.Append(HttpRequest.QueryString.Value.ClearQueryStringPassword());
             }

--- a/Lucca.Logs.AspnetCore/HttpContextParserCore.cs
+++ b/Lucca.Logs.AspnetCore/HttpContextParserCore.cs
@@ -18,9 +18,9 @@ namespace Lucca.Logs.AspnetCore
         }
 
 
-        public Guid? ExceptionalLog(Exception exception, Dictionary<string, string> customData, string categoryName, string appName)
+        public Guid? ExceptionalLog(Exception exception, Dictionary<string, string?> customData, string categoryName, string appName)
         {
-            if (exception == null)
+            if (exception is null)
             {
                 return null;
             }
@@ -29,7 +29,7 @@ namespace Lucca.Logs.AspnetCore
 
             var request = _httpContextAccessor?.HttpContext?.Request;
 
-            if (request?.HttpContext != null)
+            if (request?.HttpContext is not null)
             {
                 error = exception.Log(request.HttpContext, categoryName, false, customData, appName);
             }
@@ -41,20 +41,22 @@ namespace Lucca.Logs.AspnetCore
             return error?.GUID;
         }
 
-        public IHttpContextRequest HttpRequestAccessor()
+        public IHttpContextRequest? HttpRequestAccessor()
         {
             var req = _httpContextAccessor?.HttpContext?.Request;
-            return req != null ? new HttpContextRequestCore(req) : null;
+            return req is not null ? new HttpContextRequestCore(req) : null;
         }
 
-        public string ExtractUrl(Uripart uriPart, IHttpContextRequest httpRequest)
+        public string? ExtractUrl(Uripart uriPart, IHttpContextRequest httpRequest)
         {
             var request = (httpRequest as HttpContextRequestCore).HttpRequest;
-            if (request == null)
+            if (request is null)
+            {
                 return null;
+            }
 
             var urlBuilder = new StringBuilder();
-            if ((uriPart & Uripart.Scheme) == Uripart.Scheme && !String.IsNullOrWhiteSpace(request.Scheme))
+            if ((uriPart & Uripart.Scheme) == Uripart.Scheme && !string.IsNullOrWhiteSpace(request.Scheme))
             {
                 urlBuilder.Append(request.Scheme + "://");
             }
@@ -81,24 +83,24 @@ namespace Lucca.Logs.AspnetCore
         public bool ContainsHeader(string header, IHttpContextRequest httpRequest)
         {
             var request = (httpRequest as HttpContextRequestCore).HttpRequest;
-            if (request == null)
+            if (request is null)
                 return false;
 
             return request.Headers.ContainsKey(header);
         }
 
-        public string GetHeader(string header, IHttpContextRequest httpRequest)
+        public string? GetHeader(string header, IHttpContextRequest httpRequest)
         {
             var request = (httpRequest as HttpContextRequestCore).HttpRequest;
             return request?.Headers[header];
         }
 
-        public string TryGetBodyContent(IHttpContextRequest httpRequest)
+        public string? TryGetBodyContent(IHttpContextRequest httpRequest)
         {
             var request = (httpRequest as HttpContextRequestCore).HttpRequest;
             try
             {
-                if (request == null || !request.Body.CanRead || !request.Body.CanSeek || request.Body.Length == 0)
+                if (request is null || !request.Body.CanRead || !request.Body.CanSeek || request.Body.Length == 0)
                 {
                     return null;
                 }
@@ -117,16 +119,16 @@ namespace Lucca.Logs.AspnetCore
             }
         }
 
-        public string GetMethod(IHttpContextRequest httpRequest)
+        public string? GetMethod(IHttpContextRequest httpRequest)
         {
             var request = (httpRequest as HttpContextRequestCore).HttpRequest;
             return request?.Method;
         }
 
-        public string HostAddress(IHttpContextRequest httpRequest)
+        public string? HostAddress(IHttpContextRequest httpRequest)
         {
             var request = (httpRequest as HttpContextRequestCore).HttpRequest;
-            string ip = null;
+            string? ip = null;
             if (request.Headers.ContainsKey(LogMeta._luccaForwardedHeader))
             {
                 ip = request.Headers[LogMeta._forwardedHeader];

--- a/Lucca.Logs.AspnetCore/Lucca.Logs.AspnetCore.csproj
+++ b/Lucca.Logs.AspnetCore/Lucca.Logs.AspnetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <VersionPrefix>0.0.0</VersionPrefix>
     <VersionSuffix>alpha</VersionSuffix>
     <PackageVersion>0.0.0</PackageVersion>

--- a/Lucca.Logs.AspnetCore/Lucca.Logs.AspnetCore.csproj
+++ b/Lucca.Logs.AspnetCore/Lucca.Logs.AspnetCore.csproj
@@ -12,11 +12,6 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
-    <PackageReference Include="NLog" Version="4.7.13" />
     <PackageReference Include="StackExchange.Exceptional.AspNetCore" Version="2.2.17" />
   </ItemGroup>
 

--- a/Lucca.Logs.AspnetCore/Lucca.Logs.AspnetCore.csproj
+++ b/Lucca.Logs.AspnetCore/Lucca.Logs.AspnetCore.csproj
@@ -6,16 +6,18 @@
     <VersionSuffix>alpha</VersionSuffix>
     <PackageVersion>0.0.0</PackageVersion>
     <RepositoryUrl>https://github.com/LuccaSA/Lucca.Logs</RepositoryUrl>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.2" />
-    <PackageReference Include="NLog" Version="4.6.8" />
-    <PackageReference Include="StackExchange.Exceptional.AspNetCore" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
+    <PackageReference Include="NLog" Version="4.7.13" />
+    <PackageReference Include="StackExchange.Exceptional.AspNetCore" Version="2.2.17" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Lucca.Logs.AspnetCore/Lucca.Logs.AspnetCore.csproj
+++ b/Lucca.Logs.AspnetCore/Lucca.Logs.AspnetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <VersionPrefix>0.0.0</VersionPrefix>
     <VersionSuffix>alpha</VersionSuffix>
     <PackageVersion>0.0.0</PackageVersion>

--- a/Lucca.Logs.AspnetCore/Lucca.Logs.AspnetCore.csproj
+++ b/Lucca.Logs.AspnetCore/Lucca.Logs.AspnetCore.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="StackExchange.Exceptional.AspNetCore" Version="2.2.17" />
+    <PackageReference Include="StackExchange.Exceptional.AspNetCore" Version="2.2.32" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Lucca.Logs.AspnetCore/LuccaExceptionHandlerMiddleware.cs
+++ b/Lucca.Logs.AspnetCore/LuccaExceptionHandlerMiddleware.cs
@@ -73,9 +73,9 @@ namespace Lucca.Logs.AspnetCore
             ClearHttpResponseResponse(context, info.StatusCode);
 
             // Extracts the Accept header
-            string acceptable = NegociateAcceptableContentType(context.Request);
+            string? acceptable = NegociateAcceptableContentType(context.Request);
 
-            if (acceptable != null)
+            if (acceptable is not null)
             {
                 if (await TryRenderErrorOnContentTypeAsync(acceptable, context, info))
                 {
@@ -103,16 +103,16 @@ namespace Lucca.Logs.AspnetCore
             await context.Response.WriteAsync(info.GenericErrorMessage);
         }
 
-        internal static string NegociateAcceptableContentType(HttpRequest httpRequest)
+        internal static string? NegociateAcceptableContentType(HttpRequest httpRequest)
         {
             var contentTypes = GetAcceptableMediaTypes(httpRequest);
             var acceptable = GetFirstAcceptableMatch(contentTypes);
             return acceptable;
         }
 
-        private static string GetFirstAcceptableMatch(IEnumerable<MediaTypeHeaderValue> contentTypes)
+        private static string? GetFirstAcceptableMatch(IEnumerable<MediaTypeHeaderValue>? contentTypes)
         {
-            if (contentTypes == null)
+            if (contentTypes is null)
             {
                 return null;
             }
@@ -177,7 +177,7 @@ namespace Lucca.Logs.AspnetCore
             await httpContext.Response.WriteAsync(data);
         }
 
-        private static List<MediaTypeHeaderValue> GetAcceptableMediaTypes(HttpRequest request)
+        private static List<MediaTypeHeaderValue>? GetAcceptableMediaTypes(HttpRequest request)
         {
             //https://developer.mozilla.org/en-US/docs/Glossary/Quality_values
             return request.GetTypedHeaders()?.Accept?.OrderByDescending(h => h.Quality ?? 1).ToList();

--- a/Lucca.Logs.AspnetCore/LuccaExceptionHandlerMiddleware.cs
+++ b/Lucca.Logs.AspnetCore/LuccaExceptionHandlerMiddleware.cs
@@ -38,7 +38,7 @@ namespace Lucca.Logs.AspnetCore
             }
             catch (Exception ex)
             {
-                _logger.LogError(0, ex, "An unhandled exception has occurred: " + ex.Message);
+                _logger.LogError(0, ex, "An unhandled exception has occurred: {message}", ex.Message);
                 if (context.Response.HasStarted)
                 {
                     _logger.LogWarning("The response has already started, the error handler will not be executed.");
@@ -100,7 +100,7 @@ namespace Lucca.Logs.AspnetCore
 
             // fallback on generic text/plain error
             context.Response.ContentType = _textPlain;
-            await context.Response.WriteAsync(info.GenericErrorMessage);
+            await context.Response.WriteAsync(info.GenericErrorMessage ?? GenericExceptionQualifier.DefaultErrorMessage);
         }
 
         internal static string? NegociateAcceptableContentType(HttpRequest httpRequest)
@@ -148,7 +148,7 @@ namespace Lucca.Logs.AspnetCore
             }
             catch (Exception e)
             {
-                _logger.LogError(0, e, "An exception was thrown attempting to render the error with content type " + contentType);
+                _logger.LogError(0, e, "An exception was thrown attempting to render the error with content type {contentType}", contentType);
             }
             return false;
         }

--- a/Lucca.Logs.AspnetCore/LuccaExceptionHandlerOption.cs
+++ b/Lucca.Logs.AspnetCore/LuccaExceptionHandlerOption.cs
@@ -24,7 +24,7 @@ namespace Lucca.Logs.AspnetCore
         public Func<LuccaExceptionBuilderInfo, Task<string>> HtmlResponse { get; set; }
         public Func<LuccaExceptionBuilderInfo, Task<string>> JsonResponse { get; set; }
 
-        public Task<string> DefaultHandler(LuccaExceptionBuilderInfo builderInfo) => Task.FromResult($"Error code: {builderInfo.StatusCode}");
+        private static Task<string> DefaultHandler(LuccaExceptionBuilderInfo builderInfo) => Task.FromResult($"Error code: {builderInfo.StatusCode}");
     }
 
     public class LuccaExceptionBuilderInfo

--- a/Lucca.Logs.AspnetCore/LuccaExceptionHandlerOption.cs
+++ b/Lucca.Logs.AspnetCore/LuccaExceptionHandlerOption.cs
@@ -20,16 +20,16 @@ namespace Lucca.Logs.AspnetCore
             HtmlResponse = i => throw new NotImplementedException();
         }
 
-        public Func<LuccaExceptionBuilderInfo, Task<String>> TextPlainResponse { get; set; }
-        public Func<LuccaExceptionBuilderInfo, Task<String>> HtmlResponse { get; set; }
-        public Func<LuccaExceptionBuilderInfo, Task<String>> JsonResponse { get; set; }
+        public Func<LuccaExceptionBuilderInfo, Task<string>> TextPlainResponse { get; set; }
+        public Func<LuccaExceptionBuilderInfo, Task<string>> HtmlResponse { get; set; }
+        public Func<LuccaExceptionBuilderInfo, Task<string>> JsonResponse { get; set; }
 
-        public Task<String> DefaultHandler(LuccaExceptionBuilderInfo builderInfo) => Task.FromResult($"Error code: {builderInfo.StatusCode}");
+        public Task<string> DefaultHandler(LuccaExceptionBuilderInfo builderInfo) => Task.FromResult($"Error code: {builderInfo.StatusCode}");
     }
 
     public class LuccaExceptionBuilderInfo
     {
-        public LuccaExceptionBuilderInfo(Exception exception, HttpStatusCode statusCode, bool displayExceptionDetails, string genericErrorMessage, string preferedResponseType)
+        public LuccaExceptionBuilderInfo(Exception exception, HttpStatusCode statusCode, bool displayExceptionDetails, string? genericErrorMessage, string? preferedResponseType)
         {
             Exception = exception;
             StatusCode = statusCode;
@@ -41,7 +41,7 @@ namespace Lucca.Logs.AspnetCore
         public Exception Exception { get; }
         public HttpStatusCode StatusCode { get; }
         public bool DisplayExceptionDetails { get; }
-        public string GenericErrorMessage { get; }
-        public string PreferedResponseType { get; }
+        public string? GenericErrorMessage { get; }
+        public string? PreferedResponseType { get; }
     }
 }

--- a/Lucca.Logs.AspnetCore/LuccaLoggerAspnetCoreExtensions.cs
+++ b/Lucca.Logs.AspnetCore/LuccaLoggerAspnetCoreExtensions.cs
@@ -5,7 +5,7 @@ namespace Lucca.Logs.AspnetCore
 {
     public static class LuccaLoggerAspnetCoreExtensions
     {
-        public static IApplicationBuilder UseLuccaLogs(this IApplicationBuilder app, LuccaExceptionHandlerOption exceptionHandlerOption = null, bool enableContentLog = true)
+        public static IApplicationBuilder UseLuccaLogs(this IApplicationBuilder app, LuccaExceptionHandlerOption? exceptionHandlerOption = null, bool enableContentLog = true)
         {
             var builder = app;
             if (enableContentLog)

--- a/Lucca.Logs.AspnetCore/LuccaLoggerExtensions.cs
+++ b/Lucca.Logs.AspnetCore/LuccaLoggerExtensions.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using StackExchange.Exceptional;
-#if NETCOREAPP3_1
+#if NET6_0
 using Microsoft.AspNetCore.Http;
 #else
 using Lucca.Logs.AspnetLegacy;
@@ -54,7 +54,7 @@ namespace Lucca.Logs.AspnetCore
             services.AddOptions();
             services.Configure<LuccaLoggerOptions>(config);
 
-#if NETCOREAPP3_1
+#if NET6_0
             services.AddExceptional(e =>
             {
                 var luccaLogsOption = config.Get<LuccaLoggerOptions>();
@@ -97,7 +97,7 @@ namespace Lucca.Logs.AspnetCore
 
             if (errorStore is not null)
             {
-#if NETCOREAPP3_1
+#if NET6_0
                 services.AddExceptional(o =>
                 {
                     o.Store.Type = errorStore.GetType().ToString();
@@ -126,7 +126,7 @@ namespace Lucca.Logs.AspnetCore
         {
             services.AddSingleton<ILogDetailsExtractor, HttpLogDetailsExtractor>();
 
-#if NETCOREAPP3_1
+#if NET6_0
             services.TryAddSingleton<IExceptionQualifier, GenericExceptionQualifier>();
             services.TryAddSingleton<IHttpContextAccessor, HttpContextAccessor>();
             services.TryAddSingleton<IHttpContextParser, HttpContextParserCore>();

--- a/Lucca.Logs.AspnetCore/LuccaLoggerExtensions.cs
+++ b/Lucca.Logs.AspnetCore/LuccaLoggerExtensions.cs
@@ -16,13 +16,13 @@ namespace Lucca.Logs.AspnetCore
 {
     public static class LuccaLoggerExtensions
     {
-        public static ILuccaLoggingBuilder AddLuccaLogs(this ILoggingBuilder loggingBuilder, IConfigurationSection config, string appName, Action<LuccaLoggerOptions> configureOptions = null)
+        public static ILuccaLoggingBuilder AddLuccaLogs(this ILoggingBuilder loggingBuilder, IConfigurationSection config, string appName, Action<LuccaLoggerOptions>? configureOptions = null)
         {
             loggingBuilder.Services.AddLuccaLogs(config, appName, configureOptions);
             return new LuccaLoggingBuilder(loggingBuilder);
         }
 
-        public static ILuccaLoggingBuilder AddLuccaLogs(this ILoggingBuilder loggingBuilder, Action<LuccaLoggerOptions> configureOptions, string appName, ErrorStore errorStore = null)
+        public static ILuccaLoggingBuilder AddLuccaLogs(this ILoggingBuilder loggingBuilder, Action<LuccaLoggerOptions> configureOptions, string appName, ErrorStore? errorStore = null)
         {
             loggingBuilder.Services.AddLuccaLogs(configureOptions, appName, errorStore);
             return new LuccaLoggingBuilder(loggingBuilder);
@@ -38,9 +38,9 @@ namespace Lucca.Logs.AspnetCore
             return luccaLoggingBuilder;
         }
 
-        private static IServiceCollection AddLuccaLogs(this IServiceCollection services, IConfigurationSection config, string appName, Action<LuccaLoggerOptions> configureOptions = null)
+        private static IServiceCollection AddLuccaLogs(this IServiceCollection services, IConfigurationSection config, string appName, Action<LuccaLoggerOptions>? configureOptions = null)
         {
-            if (config == null)
+            if (config is null)
             {
                 throw new ArgumentNullException(nameof(config));
             }
@@ -62,7 +62,7 @@ namespace Lucca.Logs.AspnetCore
                 e.DefaultStore = luccaLogsOption.GenerateExceptionalStore();
             });
 #endif
-            if (configureOptions != null)
+            if (configureOptions is not null)
             {
                 services.Configure(configureOptions);
             }
@@ -78,7 +78,7 @@ namespace Lucca.Logs.AspnetCore
             return services;
         }
 
-        private static IServiceCollection AddLuccaLogs(this IServiceCollection services, Action<LuccaLoggerOptions> configureOptions, string appName, ErrorStore errorStore = null)
+        private static IServiceCollection AddLuccaLogs(this IServiceCollection services, Action<LuccaLoggerOptions> configureOptions, string appName, ErrorStore? errorStore = null)
         {
             if (string.IsNullOrWhiteSpace(appName))
             {
@@ -87,7 +87,7 @@ namespace Lucca.Logs.AspnetCore
 
             services.AddOptions();
 
-            if (configureOptions != null)
+            if (configureOptions is not null)
             {
                 services.Configure<LuccaLoggerOptions>(o =>
                 {
@@ -96,7 +96,7 @@ namespace Lucca.Logs.AspnetCore
                 });
             }
 
-            if (errorStore != null)
+            if (errorStore is not null)
             {
 #if NETCOREAPP3_1
                 services.AddExceptional(o =>

--- a/Lucca.Logs.AspnetCore/LuccaLoggerExtensions.cs
+++ b/Lucca.Logs.AspnetCore/LuccaLoggerExtensions.cs
@@ -30,10 +30,7 @@ namespace Lucca.Logs.AspnetCore
 
         public static ILoggingBuilder WithCloudEvents(this ILuccaLoggingBuilder luccaLoggingBuilder, Func<CloudEvent> cloudEventAccessor)
         {
-            luccaLoggingBuilder.Services.PostConfigure<LuccaLoggerOptions>(o =>
-            {
-                o.CloudEventAccessor = cloudEventAccessor;
-            });
+            luccaLoggingBuilder.Services.PostConfigure<LuccaLoggerOptions>(o => o.CloudEventAccessor = cloudEventAccessor);
             luccaLoggingBuilder.Services.AddSingleton<ILogDetailsExtractor, CloudEventExtractor>();
             return luccaLoggingBuilder;
         }
@@ -53,8 +50,10 @@ namespace Lucca.Logs.AspnetCore
             {
                 throw new LogConfigurationException("Missing configuration section");
             }
+
             services.AddOptions();
             services.Configure<LuccaLoggerOptions>(config);
+
 #if NETCOREAPP3_1
             services.AddExceptional(e =>
             {

--- a/Lucca.Logs.AspnetCore/LuccaLoggerExtensions.cs
+++ b/Lucca.Logs.AspnetCore/LuccaLoggerExtensions.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using StackExchange.Exceptional;
-#if NET6_0
+#if NET6_0_OR_GREATER
 using Microsoft.AspNetCore.Http;
 #else
 using Lucca.Logs.AspnetLegacy;
@@ -54,7 +54,7 @@ namespace Lucca.Logs.AspnetCore
             services.AddOptions();
             services.Configure<LuccaLoggerOptions>(config);
 
-#if NET6_0
+#if NET6_0_OR_GREATER
             services.AddExceptional(e =>
             {
                 var luccaLogsOption = config.Get<LuccaLoggerOptions>();
@@ -97,7 +97,7 @@ namespace Lucca.Logs.AspnetCore
 
             if (errorStore is not null)
             {
-#if NET6_0
+#if NET6_0_OR_GREATER
                 services.AddExceptional(o =>
                 {
                     o.Store.Type = errorStore.GetType().ToString();
@@ -126,7 +126,7 @@ namespace Lucca.Logs.AspnetCore
         {
             services.AddSingleton<ILogDetailsExtractor, HttpLogDetailsExtractor>();
 
-#if NET6_0
+#if NET6_0_OR_GREATER
             services.TryAddSingleton<IExceptionQualifier, GenericExceptionQualifier>();
             services.TryAddSingleton<IHttpContextAccessor, HttpContextAccessor>();
             services.TryAddSingleton<IHttpContextParser, HttpContextParserCore>();

--- a/Lucca.Logs.AspnetLegacy/ExceptionLoggerHelper.cs
+++ b/Lucca.Logs.AspnetLegacy/ExceptionLoggerHelper.cs
@@ -11,20 +11,20 @@ namespace Lucca.Logs.AspnetLegacy
         /// <summary>
         /// Helps logging an exception in an HttpContext
         /// </summary>
-        public static void HttpLog(this Exception exception, HttpControllerContext context)
+        public static void HttpLog(this Exception exception, HttpControllerContext? context)
         {
             Logger.LogException(exception, context.TryGetAppName() ?? DefaultAppName);
         }
 
-        private static string TryGetAppName(this HttpControllerContext controllerContext)
+        private static string? TryGetAppName(this HttpControllerContext? controllerContext)
         {
-            if (controllerContext?.ControllerDescriptor?.ControllerType == null)
+            if (controllerContext?.ControllerDescriptor?.ControllerType is null)
             {
                 return null;
             }
 
             string appNameSpace = controllerContext.ControllerDescriptor.ControllerType.Namespace;
-            if (appNameSpace != null)
+            if (appNameSpace is not null)
             {
                 string[] nsChunks = appNameSpace.Split('.');
                 if (nsChunks.Length > 0)

--- a/Lucca.Logs.AspnetLegacy/HttpContextParserLegacy.cs
+++ b/Lucca.Logs.AspnetLegacy/HttpContextParserLegacy.cs
@@ -62,26 +62,26 @@ namespace Lucca.Logs.AspnetLegacy
             HttpRequest = httpRequest;
         }
 
-        public string ExtractUrl(Uripart uriPart)
+        public string ExtractUrl(Uriparts uriPart)
         {
             var urlBuilder = new StringBuilder();
-            if ((uriPart & Uripart.Scheme) == Uripart.Scheme && !string.IsNullOrWhiteSpace(HttpRequest.Url.Scheme))
+            if ((uriPart & Uriparts.Scheme) == Uriparts.Scheme && !string.IsNullOrWhiteSpace(HttpRequest.Url.Scheme))
             {
                 urlBuilder.Append(HttpRequest.Url.Scheme + "://");
             }
-            if ((uriPart & Uripart.Host) == Uripart.Host)
+            if ((uriPart & Uriparts.Host) == Uriparts.Host)
             {
                 urlBuilder.Append(HttpRequest.Url.DnsSafeHost);
             }
-            if ((uriPart & Uripart.Port) == Uripart.Port && HttpRequest.Url.Port > 0)
+            if ((uriPart & Uriparts.Port) == Uriparts.Port && HttpRequest.Url.Port > 0)
             {
                 urlBuilder.Append(":" + HttpRequest.Url.Port);
             }
-            if ((uriPart & Uripart.Path) == Uripart.Path)
+            if ((uriPart & Uriparts.Path) == Uriparts.Path)
             {
                 urlBuilder.Append(HttpRequest.Url.LocalPath);
             }
-            if ((uriPart & Uripart.Query) == Uripart.Query)
+            if ((uriPart & Uriparts.Query) == Uriparts.Query)
             {
                 urlBuilder.Append(HttpRequest.Url.Query.ClearQueryStringPassword());
             }

--- a/Lucca.Logs.AspnetLegacy/HttpContextParserLegacy.cs
+++ b/Lucca.Logs.AspnetLegacy/HttpContextParserLegacy.cs
@@ -38,74 +38,6 @@ namespace Lucca.Logs.AspnetLegacy
             return error?.GUID;
         }
 
-        public string? ExtractUrl(Uripart uriPart, IHttpContextRequest httpRequest)
-        {
-            var request = (httpRequest as HttpContextRequestLegacy).HttpRequest;
-            if (request is null)
-            {
-                return null;
-            }
-
-            var urlBuilder = new StringBuilder();
-            if ((uriPart & Uripart.Scheme) == Uripart.Scheme && !string.IsNullOrWhiteSpace(request.Url.Scheme))
-            {
-                urlBuilder.Append(request.Url.Scheme + "://");
-            }
-            if ((uriPart & Uripart.Host) == Uripart.Host)
-            {
-                urlBuilder.Append(request.Url.DnsSafeHost);
-            }
-            if ((uriPart & Uripart.Port) == Uripart.Port && request.Url.Port > 0)
-            {
-                urlBuilder.Append(":" + request.Url.Port);
-            }
-            if ((uriPart & Uripart.Path) == Uripart.Path)
-            {
-                urlBuilder.Append(request.Url.LocalPath);
-            }
-            if ((uriPart & Uripart.Query) == Uripart.Query)
-            {
-                urlBuilder.Append(request.Url.Query.ClearQueryStringPassword());
-            }
-            return urlBuilder.ToString();
-        }
-
-        public bool ContainsHeader(string header, IHttpContextRequest httpRequest)
-        {
-            var request = (httpRequest as HttpContextRequestLegacy).HttpRequest;
-            return request?.Headers.Get(header) is not null;
-        }
-
-        public string? GetHeader(string header, IHttpContextRequest httpRequest)
-        {
-            var request = (httpRequest as HttpContextRequestLegacy).HttpRequest;
-            return request?.Headers.Get(header);
-        }
-
-        public string? TryGetBodyContent(IHttpContextRequest httpRequest)
-        {
-            var request = (httpRequest as HttpContextRequestLegacy).HttpRequest;
-            string? documentContents = null;
-            try
-            {
-                if (request is null || request.InputStream.Length == 0)
-                {
-                    return null;
-                }
-                using (var stream = new MemoryStream())
-                {
-                    request.InputStream.Seek(0, SeekOrigin.Begin);
-                    request.InputStream.CopyTo(stream);
-                    documentContents = Encoding.UTF8.GetString(stream.ToArray());
-                }
-            }
-            catch (Exception)
-            {
-                // discard exception
-            }
-            return documentContents;
-        }
-
         public IHttpContextRequest? HttpRequestAccessor()
         {
             HttpRequest? request = null;
@@ -119,27 +51,6 @@ namespace Lucca.Logs.AspnetLegacy
             } 
             return request is not null ? new HttpContextRequestLegacy(request) : null;
         }
-
-        public string? GetMethod(IHttpContextRequest httpRequest)
-        {
-            var request = (httpRequest as HttpContextRequestLegacy).HttpRequest;
-            return request?.HttpMethod;
-        }
-
-        public string? HostAddress(IHttpContextRequest httpRequest)
-        {
-            var request = (httpRequest as HttpContextRequestLegacy).HttpRequest;
-            string? ip = null;
-            if (request.Headers.Get(LogMeta._luccaForwardedHeader) is not null)
-            {
-                ip = request.Headers[LogMeta._forwardedHeader];
-            }
-            if (string.IsNullOrEmpty(ip))
-            {
-                ip = request?.UserHostAddress;
-            }
-            return ip;
-        }
     }
 
     public class HttpContextRequestLegacy : IHttpContextRequest
@@ -149,6 +60,85 @@ namespace Lucca.Logs.AspnetLegacy
         public HttpContextRequestLegacy(HttpRequest httpRequest)
         {
             HttpRequest = httpRequest;
+        }
+
+        public string ExtractUrl(Uripart uriPart)
+        {
+            var urlBuilder = new StringBuilder();
+            if ((uriPart & Uripart.Scheme) == Uripart.Scheme && !string.IsNullOrWhiteSpace(HttpRequest.Url.Scheme))
+            {
+                urlBuilder.Append(HttpRequest.Url.Scheme + "://");
+            }
+            if ((uriPart & Uripart.Host) == Uripart.Host)
+            {
+                urlBuilder.Append(HttpRequest.Url.DnsSafeHost);
+            }
+            if ((uriPart & Uripart.Port) == Uripart.Port && HttpRequest.Url.Port > 0)
+            {
+                urlBuilder.Append(":" + HttpRequest.Url.Port);
+            }
+            if ((uriPart & Uripart.Path) == Uripart.Path)
+            {
+                urlBuilder.Append(HttpRequest.Url.LocalPath);
+            }
+            if ((uriPart & Uripart.Query) == Uripart.Query)
+            {
+                urlBuilder.Append(HttpRequest.Url.Query.ClearQueryStringPassword());
+            }
+            return urlBuilder.ToString();
+        }
+
+        public bool ContainsHeader(string header)
+        {
+            return HttpRequest.Headers.Get(header) is not null;
+        }
+
+        public string? GetHeader(string header)
+        {
+            return HttpRequest.Headers.Get(header);
+        }
+
+        public string? TryGetBodyContent()
+        {
+            if (HttpRequest.InputStream.Length == 0)
+            {
+                return null;
+            }
+
+            string? documentContents = null;
+            try
+            {
+                using (var stream = new MemoryStream())
+                {
+                    HttpRequest.InputStream.Seek(0, SeekOrigin.Begin);
+                    HttpRequest.InputStream.CopyTo(stream);
+                    documentContents = Encoding.UTF8.GetString(stream.ToArray());
+                }
+            }
+            catch (Exception)
+            {
+                // discard exception
+            }
+            return documentContents;
+        }
+
+        public string GetMethod()
+        {
+            return HttpRequest.HttpMethod;
+        }
+
+        public string? HostAddress()
+        {
+            string? ip = null;
+            if (HttpRequest.Headers.Get(LogMeta._luccaForwardedHeader) is not null)
+            {
+                ip = HttpRequest.Headers[LogMeta._forwardedHeader];
+            }
+            if (string.IsNullOrEmpty(ip))
+            {
+                ip = HttpRequest.UserHostAddress;
+            }
+            return ip;
         }
     }
 }

--- a/Lucca.Logs.AspnetLegacy/HttpContextParserLegacy.cs
+++ b/Lucca.Logs.AspnetLegacy/HttpContextParserLegacy.cs
@@ -17,16 +17,16 @@ namespace Lucca.Logs.AspnetLegacy
             _httpContextAccessor = httpContextAccessor;
         }
        
-        public Guid? ExceptionalLog(Exception exception, Dictionary<string, string> customData, string categoryName, string appName)
+        public Guid? ExceptionalLog(Exception exception, Dictionary<string, string?> customData, string categoryName, string appName)
         {
-            if (exception == null)
+            if (exception is null)
             {
                 return null;
             }
 
             Error error;
             var ctx = _httpContextAccessor?.HttpContext;
-            if (ctx != null)
+            if (ctx is not null)
             {
                 error = exception.Log(ctx, categoryName, false, customData, appName);
             }
@@ -38,14 +38,16 @@ namespace Lucca.Logs.AspnetLegacy
             return error?.GUID;
         }
 
-        public string ExtractUrl(Uripart uriPart, IHttpContextRequest httpRequest)
+        public string? ExtractUrl(Uripart uriPart, IHttpContextRequest httpRequest)
         {
             var request = (httpRequest as HttpContextRequestLegacy).HttpRequest;
-            if (request == null)
+            if (request is null)
+            {
                 return null;
+            }
 
             var urlBuilder = new StringBuilder();
-            if ((uriPart & Uripart.Scheme) == Uripart.Scheme && !String.IsNullOrWhiteSpace(request.Url.Scheme))
+            if ((uriPart & Uripart.Scheme) == Uripart.Scheme && !string.IsNullOrWhiteSpace(request.Url.Scheme))
             {
                 urlBuilder.Append(request.Url.Scheme + "://");
             }
@@ -71,22 +73,22 @@ namespace Lucca.Logs.AspnetLegacy
         public bool ContainsHeader(string header, IHttpContextRequest httpRequest)
         {
             var request = (httpRequest as HttpContextRequestLegacy).HttpRequest;
-            return request?.Headers.Get(header) != null;
+            return request?.Headers.Get(header) is not null;
         }
 
-        public string GetHeader(string header, IHttpContextRequest httpRequest)
+        public string? GetHeader(string header, IHttpContextRequest httpRequest)
         {
             var request = (httpRequest as HttpContextRequestLegacy).HttpRequest;
             return request?.Headers.Get(header);
         }
 
-        public string TryGetBodyContent(IHttpContextRequest httpRequest)
+        public string? TryGetBodyContent(IHttpContextRequest httpRequest)
         {
             var request = (httpRequest as HttpContextRequestLegacy).HttpRequest;
-            string documentContents = null;
+            string? documentContents = null;
             try
             {
-                if (request == null || request.InputStream.Length == 0)
+                if (request is null || request.InputStream.Length == 0)
                 {
                     return null;
                 }
@@ -104,9 +106,9 @@ namespace Lucca.Logs.AspnetLegacy
             return documentContents;
         }
 
-        public IHttpContextRequest HttpRequestAccessor()
+        public IHttpContextRequest? HttpRequestAccessor()
         {
-            HttpRequest request = null;
+            HttpRequest? request = null;
             try
             {
                 request = _httpContextAccessor?.HttpContext?.Request;
@@ -115,20 +117,20 @@ namespace Lucca.Logs.AspnetLegacy
             {
                 // ignored
             } 
-            return request != null ? new HttpContextRequestLegacy(request) : null;
+            return request is not null ? new HttpContextRequestLegacy(request) : null;
         }
 
-        public string GetMethod(IHttpContextRequest httpRequest)
+        public string? GetMethod(IHttpContextRequest httpRequest)
         {
             var request = (httpRequest as HttpContextRequestLegacy).HttpRequest;
             return request?.HttpMethod;
         }
 
-        public string HostAddress(IHttpContextRequest httpRequest)
+        public string? HostAddress(IHttpContextRequest httpRequest)
         {
             var request = (httpRequest as HttpContextRequestLegacy).HttpRequest;
-            string ip = null;
-            if (request.Headers.Get(LogMeta._luccaForwardedHeader) != null)
+            string? ip = null;
+            if (request.Headers.Get(LogMeta._luccaForwardedHeader) is not null)
             {
                 ip = request.Headers[LogMeta._forwardedHeader];
             }

--- a/Lucca.Logs.AspnetLegacy/HttpContextParserLegacy.cs
+++ b/Lucca.Logs.AspnetLegacy/HttpContextParserLegacy.cs
@@ -39,15 +39,7 @@ namespace Lucca.Logs.AspnetLegacy
 
         public IHttpContextRequest? HttpRequestAccessor()
         {
-            HttpRequest? request = null;
-            try
-            {
-                request = _httpContextAccessor?.HttpContext?.Request;
-            }
-            catch (Exception)
-            {
-                // ignored
-            } 
+            var request = _httpContextAccessor?.HttpContext?.Request;
             return request is not null ? new HttpContextRequestLegacy(request) : null;
         }
     }

--- a/Lucca.Logs.AspnetLegacy/Logger.cs
+++ b/Lucca.Logs.AspnetLegacy/Logger.cs
@@ -13,14 +13,14 @@ namespace Lucca.Logs.AspnetLegacy
 
         public static ILoggerFactory GetFactory => DefaultFactory ?? _defaultLogger.Value;
 
-        public static ILoggerFactory DefaultFactory { get; set; }
+        public static ILoggerFactory? DefaultFactory { get; set; }
 
         /// <summary>
         /// Logs an exception
         /// </summary>
         /// <param name="ex">The exception to log</param>
         /// <param name="appName">The current application name</param>
-        public static void LogException(Exception ex, string appName, string message = null)
+        public static void LogException(Exception ex, string appName, string? message = null)
         {
             GetFactory.CreateLogger(appName).LogError(ex, message);
         }

--- a/Lucca.Logs.AspnetLegacy/Logger.cs
+++ b/Lucca.Logs.AspnetLegacy/Logger.cs
@@ -6,10 +6,7 @@ namespace Lucca.Logs.AspnetLegacy
 {
     public static class Logger
     {
-        private static readonly Lazy<ILoggerFactory> _defaultLogger = new Lazy<ILoggerFactory>(() =>
-        {
-            return LoggerBuilder.CreateLuccaLogsFactory(_ => { });
-        });
+        private static readonly Lazy<ILoggerFactory> _defaultLogger = new(() => LoggerBuilder.CreateLuccaLogsFactory(_ => { }));
 
         public static ILoggerFactory GetFactory => DefaultFactory ?? _defaultLogger.Value;
 

--- a/Lucca.Logs.AspnetLegacy/LoggerBuilder.cs
+++ b/Lucca.Logs.AspnetLegacy/LoggerBuilder.cs
@@ -14,7 +14,7 @@ namespace Lucca.Logs.AspnetLegacy
                 .GetRequiredService<ILoggerFactory>();
         }
 
-        private static readonly ServiceCollection _serviceCollection = new ServiceCollection();
+        private static readonly ServiceCollection _serviceCollection = new();
    
         public static ILoggerFactory CreateLuccaLogsFactory(Action<ILoggingBuilder> configure)
         {

--- a/Lucca.Logs.AspnetLegacy/LoggerHelper.cs
+++ b/Lucca.Logs.AspnetLegacy/LoggerHelper.cs
@@ -5,7 +5,13 @@ namespace Lucca.Logs.AspnetLegacy
 {
     public static class LoggerHelper
     {
+        [Obsolete("appName is unused")]
         public static void LogException<T>(this T sourceInstance, Exception ex, string appName, string? message = null)
+        {
+            Logger.GetFactory.CreateLogger<T>().LogError(ex, message);
+        }
+
+        public static void LogException<T>(this T _, Exception ex, string? message = null)
         {
             Logger.GetFactory.CreateLogger<T>().LogError(ex, message);
         }

--- a/Lucca.Logs.AspnetLegacy/LoggerHelper.cs
+++ b/Lucca.Logs.AspnetLegacy/LoggerHelper.cs
@@ -5,7 +5,7 @@ namespace Lucca.Logs.AspnetLegacy
 {
     public static class LoggerHelper
     {
-        public static void LogException<T>(this T sourceInstance, Exception ex, string appName, string message = null)
+        public static void LogException<T>(this T sourceInstance, Exception ex, string appName, string? message = null)
         {
             Logger.GetFactory.CreateLogger<T>().LogError(ex, message);
         }

--- a/Lucca.Logs.AspnetLegacy/Lucca.Logs.AspnetLegacy.csproj
+++ b/Lucca.Logs.AspnetLegacy/Lucca.Logs.AspnetLegacy.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.2.7" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-    <PackageReference Include="StackExchange.Exceptional" Version="2.2.17" />
+    <PackageReference Include="StackExchange.Exceptional" Version="2.2.32" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Lucca.Logs.AspnetLegacy/Lucca.Logs.AspnetLegacy.csproj
+++ b/Lucca.Logs.AspnetLegacy/Lucca.Logs.AspnetLegacy.csproj
@@ -6,6 +6,8 @@
     <VersionSuffix>alpha</VersionSuffix>
     <PackageVersion>0.0.0</PackageVersion>
     <RepositoryUrl>https://github.com/LuccaSA/Lucca.Logs</RepositoryUrl>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -15,8 +17,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.2.7" />
     <PackageReference Include="Microsoft.AspNet.WebApi.WebHost" Version="5.2.7" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.2" />
-    <PackageReference Include="StackExchange.Exceptional" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="StackExchange.Exceptional" Version="2.2.17" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Lucca.Logs.AspnetLegacy/Lucca.Logs.AspnetLegacy.csproj
+++ b/Lucca.Logs.AspnetLegacy/Lucca.Logs.AspnetLegacy.csproj
@@ -16,8 +16,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.2.7" />
-    <PackageReference Include="Microsoft.AspNet.WebApi.WebHost" Version="5.2.7" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="StackExchange.Exceptional" Version="2.2.17" />
   </ItemGroup>
 

--- a/Lucca.Logs.AspnetLegacy/LuccaExceptionHandler.cs
+++ b/Lucca.Logs.AspnetLegacy/LuccaExceptionHandler.cs
@@ -13,8 +13,7 @@ namespace Lucca.Logs.AspnetLegacy
     {
         private void Handle(ExceptionHandlerContext context)
         {
-            IExceptionQualifier? efilter = context.RequestContext.Configuration.DependencyResolver.GetService(typeof(IExceptionQualifier)) as IExceptionQualifier;
-            if (efilter is null)
+            if (context.RequestContext.Configuration.DependencyResolver.GetService(typeof(IExceptionQualifier)) is not IExceptionQualifier efilter)
             {
                 return;
             }
@@ -43,9 +42,11 @@ namespace Lucca.Logs.AspnetLegacy
 
             public Task<HttpResponseMessage> ExecuteAsync(CancellationToken cancellationToken)
             {
-                HttpResponseMessage response = new HttpResponseMessage(HttpStatusCode.InternalServerError);
-                response.Content = new StringContent(Content);
-                response.RequestMessage = Request;
+                HttpResponseMessage response = new HttpResponseMessage(HttpStatusCode.InternalServerError)
+                {
+                    Content = new StringContent(Content),
+                    RequestMessage = Request
+                };
                 return Task.FromResult(response);
             }
         }

--- a/Lucca.Logs.AspnetLegacy/LuccaExceptionHandler.cs
+++ b/Lucca.Logs.AspnetLegacy/LuccaExceptionHandler.cs
@@ -14,7 +14,6 @@ namespace Lucca.Logs.AspnetLegacy
         private void Handle(ExceptionHandlerContext context)
         {
             IExceptionQualifier? efilter = context.RequestContext.Configuration.DependencyResolver.GetService(typeof(IExceptionQualifier)) as IExceptionQualifier;
-
             if (efilter is null)
             {
                 return;

--- a/Lucca.Logs.AspnetLegacy/LuccaExceptionLogger.cs
+++ b/Lucca.Logs.AspnetLegacy/LuccaExceptionLogger.cs
@@ -7,7 +7,7 @@ namespace Lucca.Logs.AspnetLegacy
     {
         public override void Log(ExceptionLoggerContext context)
         {
-            HttpControllerContext controllerContext = context.ExceptionContext?.ControllerContext;
+            HttpControllerContext? controllerContext = context.ExceptionContext?.ControllerContext;
             context.Exception.HttpLog(controllerContext);
         }
     }

--- a/Lucca.Logs.Netcore3.Tests/Lucca.Logs.Netcore.Tests.csproj
+++ b/Lucca.Logs.Netcore3.Tests/Lucca.Logs.Netcore.Tests.csproj
@@ -10,11 +10,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Lucca.Logs.Netcore3.Tests/Lucca.Logs.Netcore.Tests.csproj
+++ b/Lucca.Logs.Netcore3.Tests/Lucca.Logs.Netcore.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 

--- a/Lucca.Logs.Netcore3.Tests/Lucca.Logs.Netcore.Tests.csproj
+++ b/Lucca.Logs.Netcore3.Tests/Lucca.Logs.Netcore.Tests.csproj
@@ -10,10 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />

--- a/Lucca.Logs.Netcore3.Tests/Lucca.Logs.Netcore.Tests.csproj
+++ b/Lucca.Logs.Netcore3.Tests/Lucca.Logs.Netcore.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
@@ -10,14 +10,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.17" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
-    <PackageReference Include="coverlet.collector" Version="3.0.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Lucca.Logs.Netcore3.Tests/NLogInjectionTest.cs
+++ b/Lucca.Logs.Netcore3.Tests/NLogInjectionTest.cs
@@ -31,7 +31,7 @@ namespace Lucca.Logs.Netcore.Tests
              
             player.Log(logLevel, 42, new Exception(), "the answer");
             
-            string expected = String.Format("the answer|{0}|Exception of type 'System.Exception' was thrown.|42", logLevel.ToNLogLevel());
+            string expected = string.Format("the answer|{0}|Exception of type 'System.Exception' was thrown.|42", logLevel.ToNLogLevel());
             Assert.Equal(expected, target.Logs.FirstOrDefault());
         }
 
@@ -54,7 +54,7 @@ namespace Lucca.Logs.Netcore.Tests
 
             player.Log(logLevel, 42, new Exception(), "the answer");
 
-            string expected = String.Format("the answer|{0}|Exception of type 'System.Exception' was thrown.|42", logLevel.ToNLogLevel());
+            string expected = string.Format("the answer|{0}|Exception of type 'System.Exception' was thrown.|42", logLevel.ToNLogLevel());
             Assert.Equal(expected, target.Logs.FirstOrDefault());
         }
 

--- a/Lucca.Logs.Shared/CloudEventExtractor.cs
+++ b/Lucca.Logs.Shared/CloudEventExtractor.cs
@@ -6,6 +6,7 @@ namespace Lucca.Logs.Shared
 {
     public class CloudEventExtractor : ILogDetailsExtractor
     {
+        private const string Event = "Event";
         private readonly IOptions<LuccaLoggerOptions> _options;
         public CloudEventExtractor(IOptions<LuccaLoggerOptions> options)
         {
@@ -17,15 +18,16 @@ namespace Lucca.Logs.Shared
             CloudEvent cloudEvent = _options.Value.CloudEventAccessor!();
             if (cloudEvent is null)
             {
-                return new LogDetail { CanExtract = false };
+                return LogDetail.NoExtraction;
             }
+
             return new LogDetail
             {
                 CanExtract = true,
                 PageRest = cloudEvent.Id,
                 PageRest2 = cloudEvent.Type,
                 Page = cloudEvent.Subject,
-                Verb = "Event",
+                Verb = Event,
                 Uri = cloudEvent.Source.ToString(),
                 ServerName = cloudEvent.Source.DnsSafeHost,
                 HostAddress = string.Empty,

--- a/Lucca.Logs.Shared/CloudEventExtractor.cs
+++ b/Lucca.Logs.Shared/CloudEventExtractor.cs
@@ -14,14 +14,14 @@ namespace Lucca.Logs.Shared
 
         public LogDetail CreateLogDetail()
         {
-            CloudEvent cloudEvent = _options.Value.CloudEventAccessor();
-            if (cloudEvent == null)
+            CloudEvent cloudEvent = _options.Value.CloudEventAccessor!();
+            if (cloudEvent is null)
             {
                 return new LogDetail { CanExtract = false };
             }
             return new LogDetail
             {
-                CanExtract = cloudEvent != null,
+                CanExtract = true,
                 PageRest = cloudEvent.Id,
                 PageRest2 = cloudEvent.Type,
                 Page = cloudEvent.Subject,
@@ -31,8 +31,7 @@ namespace Lucca.Logs.Shared
                 HostAddress = string.Empty,
                 UserAgent = cloudEvent.SpecVersion.ToString(),
                 CorrelationId = cloudEvent.Extension<DistributedTracingExtension>()?.TraceParent ?? string.Empty,
-                Payload = cloudEvent.Data.ToString(),
-                Warning = string.Empty
+                Payload = cloudEvent.Data.ToString()
             };
         }
     }

--- a/Lucca.Logs.Shared/EnvironmentDetailsExtractor.cs
+++ b/Lucca.Logs.Shared/EnvironmentDetailsExtractor.cs
@@ -10,7 +10,7 @@ namespace Lucca.Logs.Shared
             _options = options;
         }
 
-        public string AppName => _options.ApplicationName;
+        public string AppName => _options.ApplicationName!;
         public string AppPool { get; } = Environment.GetEnvironmentVariable("APP_POOL_ID", EnvironmentVariableTarget.Process);
     }
 }

--- a/Lucca.Logs.Shared/HttpLogDetailsExtractor.cs
+++ b/Lucca.Logs.Shared/HttpLogDetailsExtractor.cs
@@ -15,23 +15,26 @@
             IHttpContextRequest? httpRequest = _httpRequest.HttpRequestAccessor();
             if (httpRequest is null)
             {
-                return new LogDetail { CanExtract = false };
+                return new LogDetail
+                {
+                    CanExtract = false,
+                    Warning = "HttpContext.Current is null"
+                };
             }
 
             return new LogDetail
             {
                 CanExtract = true,
-                PageRest = _httpRequest.ExtractUrl(Uripart.Path | Uripart.Query, httpRequest),
-                PageRest2 = _httpRequest.ExtractUrl(Uripart.Path | Uripart.Query, httpRequest),
-                Page = _httpRequest.ExtractUrl(Uripart.Full, httpRequest),
-                Verb = _httpRequest.GetMethod(httpRequest),
-                Uri = _httpRequest.ExtractUrl(Uripart.Path, httpRequest),
-                ServerName = _httpRequest.ExtractUrl(Uripart.Host, httpRequest),
-                HostAddress = _httpRequest.HostAddress(httpRequest),
-                UserAgent = _httpRequest.GetHeader("User-Agent", httpRequest),
-                CorrelationId = _httpRequest.GetHeader(LogMeta._correlationId, httpRequest),
-                Payload = _httpRequest.TryGetBodyContent(httpRequest),
-                Warning = _httpRequest is null ? "HttpContext.Current is null" : null
+                PageRest = httpRequest.ExtractUrl(Uripart.Path | Uripart.Query),
+                PageRest2 = httpRequest.ExtractUrl(Uripart.Path | Uripart.Query),
+                Page = httpRequest.ExtractUrl(Uripart.Full),
+                Verb = httpRequest.GetMethod(),
+                Uri = httpRequest.ExtractUrl(Uripart.Path),
+                ServerName = httpRequest.ExtractUrl(Uripart.Host),
+                HostAddress = httpRequest.HostAddress(),
+                UserAgent = httpRequest.GetHeader("User-Agent"),
+                CorrelationId = httpRequest.GetHeader(LogMeta._correlationId),
+                Payload = httpRequest.TryGetBodyContent()
             };
 
         }

--- a/Lucca.Logs.Shared/HttpLogDetailsExtractor.cs
+++ b/Lucca.Logs.Shared/HttpLogDetailsExtractor.cs
@@ -12,8 +12,8 @@
          
         public LogDetail CreateLogDetail()
         {
-            IHttpContextRequest httpRequest = _httpRequest.HttpRequestAccessor();
-            if (httpRequest == null)
+            IHttpContextRequest? httpRequest = _httpRequest.HttpRequestAccessor();
+            if (httpRequest is null)
             {
                 return new LogDetail { CanExtract = false };
             }
@@ -31,7 +31,7 @@
                 UserAgent = _httpRequest.GetHeader("User-Agent", httpRequest),
                 CorrelationId = _httpRequest.GetHeader(LogMeta._correlationId, httpRequest),
                 Payload = _httpRequest.TryGetBodyContent(httpRequest),
-                Warning = _httpRequest == null ? "HttpContext.Current is null" : null
+                Warning = _httpRequest is null ? "HttpContext.Current is null" : null
             };
 
         }

--- a/Lucca.Logs.Shared/HttpLogDetailsExtractor.cs
+++ b/Lucca.Logs.Shared/HttpLogDetailsExtractor.cs
@@ -2,6 +2,7 @@
 {
     public class HttpLogDetailsExtractor : ILogDetailsExtractor
     {
+        private const string UserAgent = "User-Agent";
         private readonly IHttpContextParser _httpRequest;
 
         public HttpLogDetailsExtractor(IHttpContextParser httpRequest)
@@ -15,11 +16,7 @@
             IHttpContextRequest? httpRequest = _httpRequest.HttpRequestAccessor();
             if (httpRequest is null)
             {
-                return new LogDetail
-                {
-                    CanExtract = false,
-                    Warning = "HttpContext.Current is null"
-                };
+                return LogDetail.NoExtraction;
             }
 
             return new LogDetail
@@ -32,11 +29,10 @@
                 Uri = httpRequest.ExtractUrl(Uriparts.Path),
                 ServerName = httpRequest.ExtractUrl(Uriparts.Host),
                 HostAddress = httpRequest.HostAddress(),
-                UserAgent = httpRequest.GetHeader("User-Agent"),
+                UserAgent = httpRequest.GetHeader(UserAgent),
                 CorrelationId = httpRequest.GetHeader(LogMeta._correlationId),
                 Payload = httpRequest.TryGetBodyContent()
             };
-
         }
     }
 }

--- a/Lucca.Logs.Shared/HttpLogDetailsExtractor.cs
+++ b/Lucca.Logs.Shared/HttpLogDetailsExtractor.cs
@@ -25,12 +25,12 @@
             return new LogDetail
             {
                 CanExtract = true,
-                PageRest = httpRequest.ExtractUrl(Uripart.Path | Uripart.Query),
-                PageRest2 = httpRequest.ExtractUrl(Uripart.Path | Uripart.Query),
-                Page = httpRequest.ExtractUrl(Uripart.Full),
+                PageRest = httpRequest.ExtractUrl(Uriparts.Path | Uriparts.Query),
+                PageRest2 = httpRequest.ExtractUrl(Uriparts.Path | Uriparts.Query),
+                Page = httpRequest.ExtractUrl(Uriparts.Full),
                 Verb = httpRequest.GetMethod(),
-                Uri = httpRequest.ExtractUrl(Uripart.Path),
-                ServerName = httpRequest.ExtractUrl(Uripart.Host),
+                Uri = httpRequest.ExtractUrl(Uriparts.Path),
+                ServerName = httpRequest.ExtractUrl(Uriparts.Host),
                 HostAddress = httpRequest.HostAddress(),
                 UserAgent = httpRequest.GetHeader("User-Agent"),
                 CorrelationId = httpRequest.GetHeader(LogMeta._correlationId),

--- a/Lucca.Logs.Shared/IHttpContextParser.cs
+++ b/Lucca.Logs.Shared/IHttpContextParser.cs
@@ -11,7 +11,7 @@ namespace Lucca.Logs.Shared
 
     public interface IHttpContextRequest
     {
-        string ExtractUrl(Uripart uriPart);
+        string ExtractUrl(Uriparts uriPart);
         bool ContainsHeader(string header);
         string? GetHeader(string header);
         string? TryGetBodyContent();

--- a/Lucca.Logs.Shared/IHttpContextParser.cs
+++ b/Lucca.Logs.Shared/IHttpContextParser.cs
@@ -5,14 +5,13 @@ namespace Lucca.Logs.Shared
 {
     public interface IHttpContextParser
     {
-        Guid? ExceptionalLog(Exception exception, Dictionary<string, string?> customData, string categoryName, string appName);
+        Guid? ExceptionalLog(Exception? exception, Dictionary<string, string?> customData, string categoryName, string appName);
         IHttpContextRequest? HttpRequestAccessor();
     }
 
     public interface IHttpContextRequest
     {
         string ExtractUrl(Uriparts uriPart);
-        bool ContainsHeader(string header);
         string? GetHeader(string header);
         string? TryGetBodyContent();
         string GetMethod();

--- a/Lucca.Logs.Shared/IHttpContextParser.cs
+++ b/Lucca.Logs.Shared/IHttpContextParser.cs
@@ -5,14 +5,14 @@ namespace Lucca.Logs.Shared
 {
     public interface IHttpContextParser
     {
-        string ExtractUrl(Uripart uriPart, IHttpContextRequest httpRequest);
+        string? ExtractUrl(Uripart uriPart, IHttpContextRequest httpRequest);
         bool ContainsHeader(string header, IHttpContextRequest httpRequest);
-        string GetHeader(string header, IHttpContextRequest httpRequest);
-        string TryGetBodyContent(IHttpContextRequest httpRequest);
-        Guid? ExceptionalLog(Exception exception, Dictionary<string, string> customData, string categoryName, string appName);
-        IHttpContextRequest HttpRequestAccessor();
-        string GetMethod(IHttpContextRequest httpRequest);
-        string HostAddress(IHttpContextRequest httpRequest);
+        string? GetHeader(string header, IHttpContextRequest httpRequest);
+        string? TryGetBodyContent(IHttpContextRequest httpRequest);
+        Guid? ExceptionalLog(Exception exception, Dictionary<string, string?> customData, string categoryName, string appName);
+        IHttpContextRequest? HttpRequestAccessor();
+        string? GetMethod(IHttpContextRequest httpRequest);
+        string? HostAddress(IHttpContextRequest httpRequest);
     }
 
     public interface IHttpContextRequest

--- a/Lucca.Logs.Shared/IHttpContextParser.cs
+++ b/Lucca.Logs.Shared/IHttpContextParser.cs
@@ -5,17 +5,17 @@ namespace Lucca.Logs.Shared
 {
     public interface IHttpContextParser
     {
-        string? ExtractUrl(Uripart uriPart, IHttpContextRequest httpRequest);
-        bool ContainsHeader(string header, IHttpContextRequest httpRequest);
-        string? GetHeader(string header, IHttpContextRequest httpRequest);
-        string? TryGetBodyContent(IHttpContextRequest httpRequest);
         Guid? ExceptionalLog(Exception exception, Dictionary<string, string?> customData, string categoryName, string appName);
         IHttpContextRequest? HttpRequestAccessor();
-        string? GetMethod(IHttpContextRequest httpRequest);
-        string? HostAddress(IHttpContextRequest httpRequest);
     }
 
     public interface IHttpContextRequest
     {
+        string ExtractUrl(Uripart uriPart);
+        bool ContainsHeader(string header);
+        string? GetHeader(string header);
+        string? TryGetBodyContent();
+        string GetMethod();
+        string? HostAddress();
     }
 }

--- a/Lucca.Logs.Shared/ILogDetailsExtractor.cs
+++ b/Lucca.Logs.Shared/ILogDetailsExtractor.cs
@@ -3,11 +3,12 @@
     public interface ILogDetailsExtractor
     {
         LogDetail CreateLogDetail();
-
     }
 
     public class LogDetail
     {
+        public static LogDetail NoExtraction = new() { CanExtract = false };
+
         public bool CanExtract { get; set; }
         public string? PageRest { get; set; }
         public string? PageRest2 { get; set; }

--- a/Lucca.Logs.Shared/ILogDetailsExtractor.cs
+++ b/Lucca.Logs.Shared/ILogDetailsExtractor.cs
@@ -9,16 +9,16 @@
     public class LogDetail
     {
         public bool CanExtract { get; set; }
-        public string PageRest { get; set; }
-        public string PageRest2 { get; set; }
-        public string Page { get; set; }
-        public string Verb { get; set; }
-        public string Uri { get; set; }
-        public string ServerName { get; set; }
-        public string HostAddress { get; set; }
-        public string UserAgent { get; set; }
-        public string CorrelationId { get; set; }
-        public string Payload { get; set; }
-        public string Warning { get; set; }
+        public string? PageRest { get; set; }
+        public string? PageRest2 { get; set; }
+        public string? Page { get; set; }
+        public string? Verb { get; set; }
+        public string? Uri { get; set; }
+        public string? ServerName { get; set; }
+        public string? HostAddress { get; set; }
+        public string? UserAgent { get; set; }
+        public string? CorrelationId { get; set; }
+        public string? Payload { get; set; }
+        public string? Warning { get; set; }
     }
 }

--- a/Lucca.Logs.Shared/LogExtractor.cs
+++ b/Lucca.Logs.Shared/LogExtractor.cs
@@ -14,9 +14,9 @@ namespace Lucca.Logs.Shared
             _environmentDetailsExtractor = environmentDetailsExtractor;
         }
 
-        public Dictionary<string, string> GatherData(bool isError)
+        public Dictionary<string, string?> GatherData(bool isError)
         {
-            var data = new Dictionary<string, string>(16);
+            var data = new Dictionary<string, string?>(16);
 
             TryAdd(LogMeta._appName, _environmentDetailsExtractor.AppName);
             TryAdd(LogMeta._appPool, _environmentDetailsExtractor.AppPool);
@@ -49,7 +49,7 @@ namespace Lucca.Logs.Shared
                 return data;
             }
 
-            void TryAdd(string key, string value)
+            void TryAdd(string key, string? value)
             {
                 if (!string.IsNullOrEmpty(value))
                 {

--- a/Lucca.Logs.Shared/LogExtractor.cs
+++ b/Lucca.Logs.Shared/LogExtractor.cs
@@ -25,7 +25,7 @@ namespace Lucca.Logs.Shared
             {
                 ILogDetailsExtractor extractor = _logDetailsExtractors[i];
 
-                var logdetail = extractor.CreateLogDetail();
+                LogDetail? logdetail = extractor.CreateLogDetail();
                 if (!logdetail.CanExtract)
                 {
                     continue;

--- a/Lucca.Logs.Shared/Lucca.Logs.Shared.csproj
+++ b/Lucca.Logs.Shared/Lucca.Logs.Shared.csproj
@@ -6,14 +6,16 @@
     <VersionSuffix>alpha</VersionSuffix>
     <PackageVersion>0.0.0</PackageVersion>
     <RepositoryUrl>https://github.com/LuccaSA/Lucca.Logs</RepositoryUrl>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.2" />
-    <PackageReference Include="NLog" Version="4.6.8" />
-    <PackageReference Include="StackExchange.Exceptional.Shared" Version="2.1.0" /> 
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
+    <PackageReference Include="NLog" Version="4.7.13" />
+    <PackageReference Include="StackExchange.Exceptional.Shared" Version="2.2.17" />
     <PackageReference Include="CloudNative.CloudEvents" Version="1.3.80" />
   </ItemGroup>
 

--- a/Lucca.Logs.Shared/Lucca.Logs.Shared.csproj
+++ b/Lucca.Logs.Shared/Lucca.Logs.Shared.csproj
@@ -11,10 +11,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
-    <PackageReference Include="NLog" Version="4.7.13" />
-    <PackageReference Include="StackExchange.Exceptional.Shared" Version="2.2.17" />
+    <PackageReference Include="NLog" Version="4.7.14" />
+    <PackageReference Include="StackExchange.Exceptional.Shared" Version="2.2.32" />
     <PackageReference Include="CloudNative.CloudEvents" Version="1.3.80" />
   </ItemGroup>
 

--- a/Lucca.Logs.Shared/Lucca.Logs.Shared.csproj
+++ b/Lucca.Logs.Shared/Lucca.Logs.Shared.csproj
@@ -11,7 +11,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
     <PackageReference Include="NLog" Version="4.7.13" />

--- a/Lucca.Logs.Shared/LuccaLogger.cs
+++ b/Lucca.Logs.Shared/LuccaLogger.cs
@@ -9,6 +9,12 @@ namespace Lucca.Logs.Shared
 {
     public class LuccaLogger : ILogger
     {
+        private const string EventId = "EventId";
+        private const string Null = "[null]";
+        private const string Id = "Id";
+        private const string Name = "Name";
+        private const string GuidFormat = "N";
+
         private static readonly object _emptyEventId = default(EventId);    // Cache boxing of empty EventId-struct
         private static readonly object _zeroEventId = default(EventId).Id;  // Cache boxing of zero EventId-Value
 
@@ -66,7 +72,7 @@ namespace Lucca.Logs.Shared
             }
 
             string message = formatter(state, exception);
-            if (message == "[null]" && exception is not null)
+            if (message == Null && exception is not null)
             {
                 message = exception.Message;
             }
@@ -97,11 +103,11 @@ namespace Lucca.Logs.Shared
 
             if (options.GuidWithPlaceHolder)
             {
-                eventInfo.Properties[LogMeta.Link] = string.Format(options.GuidLink, guid.Value.ToString("N"));
+                eventInfo.Properties[LogMeta.Link] = string.Format(options.GuidLink, guid.Value.ToString(GuidFormat));
             }
             else
             {
-                eventInfo.Properties[LogMeta.Link] = options.GuidLink + guid.Value.ToString("N");
+                eventInfo.Properties[LogMeta.Link] = options.GuidLink + guid.Value.ToString(GuidFormat);
             }
         }
 
@@ -120,15 +126,15 @@ namespace Lucca.Logs.Shared
                     // Perform atomic cache update of the string-allocations matching the current separator
                     eventIdPropertyNames = new Tuple<string?, string?, string?>(
                         eventIdSeparator,
-                        string.Concat("EventId", eventIdSeparator, "Id"),
-                        string.Concat("EventId", eventIdSeparator, "Name"));
+                        string.Concat(EventId, eventIdSeparator, Id),
+                        string.Concat(EventId, eventIdSeparator, Name));
                     _eventIdPropertyNames = eventIdPropertyNames;
                 }
 
                 bool idIsZero = eventId.Id == 0;
                 eventInfo.Properties[eventIdPropertyNames.Item2] = idIsZero ? _zeroEventId : eventId.Id;
                 eventInfo.Properties[eventIdPropertyNames.Item3] = eventId.Name;
-                eventInfo.Properties["EventId"] = idIsZero && eventId.Name is null ? _emptyEventId : eventId;
+                eventInfo.Properties[EventId] = idIsZero && eventId.Name is null ? _emptyEventId : eventId;
             }
 
             return eventInfo;

--- a/Lucca.Logs.Shared/LuccaLoggerOptions.cs
+++ b/Lucca.Logs.Shared/LuccaLoggerOptions.cs
@@ -37,6 +37,7 @@ namespace Lucca.Logs.Shared
         /// <example>"http://opserver.lucca.local/exceptions/detail?id={0}"</example>
         public string GuidLink { get; set; } = "http://opserver.lucca.local/exceptions/detail?id={0}";
 
+        private bool? _guidWithPlaceHolder;
         public bool GuidWithPlaceHolder
         {
             get
@@ -53,6 +54,7 @@ namespace Lucca.Logs.Shared
         /// Separator between for EventId.Id and EventId.Name. Default to .
         /// </summary>
         public string EventIdSeparator { get; set; }
+
         /// <summary>
         /// Skip allocation of <see cref="LogEventInfo.Properties" />-dictionary
         /// </summary>
@@ -62,7 +64,8 @@ namespace Lucca.Logs.Shared
         public bool IgnoreEmptyEventId { get; set; }
 
         internal Func<CloudEvent>? CloudEventAccessor { get; set; }
-        
+
+        private LoggingConfiguration? _nlog;
         public LoggingConfiguration Nlog
         {
             get => _nlog ??= GenerateLuccaDefaultConfig();
@@ -70,9 +73,6 @@ namespace Lucca.Logs.Shared
         }
 
         internal ErrorStore? ExplicitErrorStore { get; set; }
-
-        private LoggingConfiguration? _nlog;
-        private bool? _guidWithPlaceHolder;
 
         public ErrorStore GenerateExceptionalStore()
         {
@@ -93,7 +93,7 @@ namespace Lucca.Logs.Shared
         {
             var nLogConfig = new LoggingConfiguration();
 
-            // FileTarget : pour stoquer localement les excpetions
+            // FileTarget : to save exceptions locally
             var fileTarget = new FileTarget("localTarget")
             {
                 FileName = LogFilePath ?? "${basedir}/logs/logfile.txt",
@@ -108,12 +108,12 @@ namespace Lucca.Logs.Shared
                 MaxArchiveFiles = 100,
                 Layout = LogMeta.LuccaJsonLayout
             };
+
             // 1Mb file size
             var fileRule = new LoggingRule("*", LogLevel.Trace, fileTarget);
             nLogConfig.LoggingRules.Add(fileRule);
 
             return nLogConfig;
         }
-
     }
 }

--- a/Lucca.Logs.Shared/LuccaLoggerOptions.cs
+++ b/Lucca.Logs.Shared/LuccaLoggerOptions.cs
@@ -19,17 +19,17 @@ namespace Lucca.Logs.Shared
         /// <summary>
         /// Default application name
         /// </summary>
-        public string ApplicationName { get; set; }
+        public string? ApplicationName { get; set; }
 
         /// <summary>
         /// Exceptional Connexion String
         /// </summary>
-        public string ConnectionString { get; set; }
+        public string? ConnectionString { get; set; }
 
         /// <summary>
         /// Custom log file path
         /// </summary>
-        public string LogFilePath { get; set; }
+        public string? LogFilePath { get; set; }
 
         /// <summary>
         /// Base URI for external link 
@@ -61,7 +61,7 @@ namespace Lucca.Logs.Shared
         ///     <c>default(EventId)</c></remarks>
         public bool IgnoreEmptyEventId { get; set; }
 
-        internal Func<CloudEvent> CloudEventAccessor { get; set; }
+        internal Func<CloudEvent>? CloudEventAccessor { get; set; }
         
         public LoggingConfiguration Nlog
         {
@@ -69,24 +69,24 @@ namespace Lucca.Logs.Shared
             set => _nlog = value;
         }
 
-        internal ErrorStore ExplicitErrorStore { get; set; }
+        internal ErrorStore? ExplicitErrorStore { get; set; }
 
-        private LoggingConfiguration _nlog;
+        private LoggingConfiguration? _nlog;
         private bool? _guidWithPlaceHolder;
 
         public ErrorStore GenerateExceptionalStore()
         {
-            if (!String.IsNullOrEmpty(ConnectionString))
+            if (!string.IsNullOrEmpty(ConnectionString))
             {
-                return new SQLErrorStore(ConnectionString, ApplicationName);
+                return new SQLErrorStore(ConnectionString, ApplicationName!);
             }
 
-            if (ExplicitErrorStore != null)
+            if (ExplicitErrorStore is not null)
             {
                 return ExplicitErrorStore;
             }
 
-            return new MemoryErrorStore(new ErrorStoreSettings { ApplicationName = ApplicationName });
+            return new MemoryErrorStore(new ErrorStoreSettings { ApplicationName = ApplicationName! });
         }
 
         private LoggingConfiguration GenerateLuccaDefaultConfig()

--- a/Lucca.Logs.Shared/LuccaLogsProvider.cs
+++ b/Lucca.Logs.Shared/LuccaLogsProvider.cs
@@ -24,10 +24,7 @@ namespace Lucca.Logs.Shared
             _exceptionalWrapper = exceptionalWrapper;
             _logDetailsExtractors = logDetailsExtractors;
 
-            _changeListener = options.OnChange((o, name) =>
-                {
-                    PropagateOptions(o);
-                });
+            _changeListener = options.OnChange((o, name) => PropagateOptions(o));
 
             PropagateOptions(_options.CurrentValue);
         }
@@ -48,7 +45,7 @@ namespace Lucca.Logs.Shared
 
                 exceptionalSetting.OnBeforeLog += (o, eb) =>
                 {
-                    var querystring = eb?.Error?.ServerVariables?.Get("QUERY_STRING");
+                    string? querystring = eb?.Error?.ServerVariables?.Get("QUERY_STRING");
                     if (querystring is not null)
                     {
                         eb!.Error.ServerVariables.Set("QUERY_STRING", querystring.ClearQueryStringPassword());
@@ -73,7 +70,7 @@ namespace Lucca.Logs.Shared
 
     internal static class CleanExtension
     {
-        private static readonly Regex _passwordClean = new Regex("(?<=[?&]" + Regex.Escape("password") + "=)[^&]*", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex _passwordClean = new("(?<=[?&]" + Regex.Escape("password") + "=)[^&]*", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         public static string? ClearQueryStringPassword(this string? source)
         {

--- a/Lucca.Logs.Shared/LuccaLogsProvider.cs
+++ b/Lucca.Logs.Shared/LuccaLogsProvider.cs
@@ -49,9 +49,9 @@ namespace Lucca.Logs.Shared
                 exceptionalSetting.OnBeforeLog += (o, eb) =>
                 {
                     var querystring = eb?.Error?.ServerVariables?.Get("QUERY_STRING");
-                    if (querystring != null)
+                    if (querystring is not null)
                     {
-                        eb.Error.ServerVariables.Set("QUERY_STRING", querystring.ClearQueryStringPassword());
+                        eb!.Error.ServerVariables.Set("QUERY_STRING", querystring.ClearQueryStringPassword());
                     }
                 };
             });
@@ -62,7 +62,7 @@ namespace Lucca.Logs.Shared
         {
             LuccaLoggerOptions opt = _options.CurrentValue;
             var logExtractor = new LogExtractor(_logDetailsExtractors, new EnvironmentDetailsExtractor(opt));
-            return new LuccaLogger(categoryName, _httpContextAccessor, LogManager.GetLogger(categoryName), opt, logExtractor, _filters, _exceptionalWrapper, _options.CurrentValue.ApplicationName);
+            return new LuccaLogger(categoryName, _httpContextAccessor, LogManager.GetLogger(categoryName), opt, logExtractor, _filters, _exceptionalWrapper, _options.CurrentValue.ApplicationName!);
         }
 
         public void Dispose()
@@ -75,9 +75,9 @@ namespace Lucca.Logs.Shared
     {
         private static readonly Regex _passwordClean = new Regex("(?<=[?&]" + Regex.Escape("password") + "=)[^&]*", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-        public static string ClearQueryStringPassword(this string source)
+        public static string? ClearQueryStringPassword(this string? source)
         {
-            if (source == null)
+            if (source is null)
             {
                 return null;
             }

--- a/Lucca.Logs.Shared/NLogHelper.cs
+++ b/Lucca.Logs.Shared/NLogHelper.cs
@@ -9,27 +9,16 @@ namespace Lucca.Logs.Shared
         /// </summary>
         /// <param name="logLevel">level to be converted.</param>
         /// <returns></returns>
-        internal static NLog.LogLevel ToNLogLevel(this LogLevel logLevel)
+        internal static NLog.LogLevel ToNLogLevel(this LogLevel logLevel) => logLevel switch
         {
-            switch (logLevel)
-            {
-                case LogLevel.Trace:
-                    return NLog.LogLevel.Trace;
-                case LogLevel.Debug:
-                    return NLog.LogLevel.Debug;
-                case LogLevel.Information:
-                    return NLog.LogLevel.Info;
-                case LogLevel.Warning:
-                    return NLog.LogLevel.Warn;
-                case LogLevel.Error:
-                    return NLog.LogLevel.Error;
-                case LogLevel.Critical:
-                    return NLog.LogLevel.Fatal;
-                case LogLevel.None:
-                    return NLog.LogLevel.Off;
-                default:
-                    return NLog.LogLevel.Debug;
-            }
-        }
+            LogLevel.Trace => NLog.LogLevel.Trace,
+            LogLevel.Debug => NLog.LogLevel.Debug,
+            LogLevel.Information => NLog.LogLevel.Info,
+            LogLevel.Warning => NLog.LogLevel.Warn,
+            LogLevel.Error => NLog.LogLevel.Error,
+            LogLevel.Critical => NLog.LogLevel.Fatal,
+            LogLevel.None => NLog.LogLevel.Off,
+            _ => NLog.LogLevel.Debug,
+        };
     }
 }

--- a/Lucca.Logs.Shared/Uriparts.cs
+++ b/Lucca.Logs.Shared/Uriparts.cs
@@ -3,7 +3,7 @@
 namespace Lucca.Logs.Shared
 {
     [Flags]
-    public enum Uripart
+    public enum Uriparts
     {
         None = 0,
         Scheme = 1,

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ Le contenu à destination de Logmatic passe par un logger NLog, et une structure
 
 Le contenu à destination de OpServer passer par un logger StackExchange.Exceptional.
 
-## Utilisation 
+## Utilisation
 
 En mode injection de dépendance, il suffit de se faire injecter un `ILogger<T>` ou un `ILoggerFactory`, puis de logger de façon standard.
 
 Plus d'infos ici : [Logging in ASP.NET Core](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging/?view=aspnetcore-2.1&tabs=aspnetcore2x)
 
-## Setup netcoreapp3.1 
+## Setup net6.0
 
 Dans la méthode `ConfigureServices` du startup.cs, ajoutez le registering suivant après `services.AddMvc();`
 
@@ -43,14 +43,14 @@ else
 
 - `app.UseDeveloperExceptionPage();` permet de bénéficier en dev local d'informations détaillées sur les exceptions lorsqu'elles se produisent
 - `app.UseLuccaLogs();` permet d'enregister le middleware permettant d'intercepter les exceptions, et de produire une erreur de sortie correspondante aux settings
-    - `LuccaExceptionHandlerOption` permet de customiser la generation du message d'erreur
-    - 3 handlers pour textplain / html et json sont disponibles
+  - `LuccaExceptionHandlerOption` permet de customiser la generation du message d'erreur
+  - 3 handlers pour textplain / html et json sont disponibles
 
 ## Setup MVC5 / net461
 
 En MVC5, la librairie utilise actuellement en interne la DI de `Microsoft.Extensions.DependencyInjection`. Il sera possible à terme de brancher n'importe quel DI framework (mais pas pour le moment)
 
-Dans le Global.asax.cs, ajouter le register suivant : 
+Dans le Global.asax.cs, ajouter le register suivant :
 
 ```csharp
 GlobalConfiguration.Configuration.Services.AddLuccaLogs();
@@ -68,13 +68,12 @@ Logger.DefaultFactory = LoggerBuilder.CreateLuccaLogsFactory(builder =>
 - `Services.AddLuccaLogs()` permet de register la lib sur les hooks de MVC5
 - `Logger.DefaultFactory = ...` permet de customiser les types registered, et d'ajouter vos propres implémentations
 
-## Utilisation
+## Utilisation net461
 
 Faites vous injecter un `ILogger<T>` dans le constructeur des classes où vous souhaitez logger.
 Utilisez les méthodes standard du framework pour logger ( `_logger.LogError(...)` etc)
 
-Lisez la doc : https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging/?view=aspnetcore-2.1
-
+Lisez la doc [à cette adresse](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging/?view=aspnetcore-2.1)
 
 ## Unit tests
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.100",
+    "version": "6.0.100",
     "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
In this PR I updated .net, the dependencies and c#10. I added nullables as well.

For breaking changes, it's mostly the transfer of methods from `IHttpContextParser` to `IHttpContextRequest`, which makes more sense if you ask me. As well:
 - drop netcoreapp3.1 support -> .net6.0
 - dependencies update (except cloudevent, this comes with breaking changes)
 - `LuccaExceptionHandlerOption.DefaultHandler` becomes `private static`
 - `LoggerHelper.LogException` become obsolete, in favor of a new signature without unused parameters
 - LogDetail.Warning is always null (instead of string.empty in cloudevents scenario)