### PR TITLE
Including Lucca.* keys in OpServer custom data

### DIFF
--- a/Lucca.Logs.AspnetCore/LuccaLoggerExtensions.cs
+++ b/Lucca.Logs.AspnetCore/LuccaLoggerExtensions.cs
@@ -9,6 +9,7 @@ using StackExchange.Exceptional;
 using Serilog.Core;
 using Microsoft.Extensions.Options;
 using Serilog;
+using System.Text.RegularExpressions;
 #if NET6_0_OR_GREATER
 using Microsoft.AspNetCore.Http;
 #else
@@ -50,6 +51,7 @@ namespace Lucca.Logs.AspnetCore
             {
                 var luccaLogsOption = config.Get<LuccaLoggerOptions>();
                 e.DefaultStore = luccaLogsOption.GenerateExceptionalStore();
+                e.DataIncludeRegex = new Regex("Lucca.*", RegexOptions.IgnoreCase | RegexOptions.Singleline | RegexOptions.Compiled);
             });
 #endif
             if (configureOptions is not null)

--- a/README.md
+++ b/README.md
@@ -102,3 +102,9 @@ Pour celà, il faut modifier le fichier `appSettings.json` du projet concerné a
 ```
 
 > Demandez le mot de passe à l'équipe plateforme.
+
+## Enrichir vos logs sur OpServer
+
+Compléter le dictionnaire `Data` de vos `Exception` en préfixant les clés avec `Lucca.`
+
+Vous retrouverez vos données custom dans la section `Custom` d'une exception sur OpServer.


### PR DESCRIPTION
# Description

On ajoute une convention permettant d'inclure dans OpServer toutes les clés commençant par `Lucca.` dans la section `Custom` d'OpServer

-----

D'autres options ont été étudiées durant l'atelier, notamment pour permettre la remontée de ces infos vers Datadog également. Les changements requis semblaient plus profonds, et on est resté sur une solution simple, pas cher et qui répond au besoin immédiat. 

À voir pour plus tard si on veut revenir dessus.

-----